### PR TITLE
Provide default title for new widgets

### DIFF
--- a/ContentWidget.php
+++ b/ContentWidget.php
@@ -25,7 +25,7 @@ class ContentWidget extends Widget{
 		if($this->Title){
 			return $this->Title;
 		}
-		return parent::Title();
+		return "New Content Widget";
 	}
 
 	function CMSTitle(){


### PR DESCRIPTION
Lets users know they're creating a Content Widget; previously displayed "Widget Title" before creation
